### PR TITLE
[DRAFT] Expose eyre features as color-eyre features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,13 @@ categories = []
 keywords = []
 
 [features]
-default = ["track-caller", "capture-spantrace"]
+default = ["track-caller", "capture-spantrace", "auto-install", "track-caller"]
 capture-spantrace = ["tracing-error", "color-spantrace"]
 issue-url = ["url"]
-track-caller = []
+track-caller = ["eyre/track-caller"]
+auto-install = ["eyre/auto-install"]
+pyo3 = ["eyre/pyo3"]
+
 
 [dependencies]
 eyre = "0.6.1"


### PR DESCRIPTION
This change exposes all eyre features as color-eyre features, allowing you to test these dependency features combinatorially with `cargo test-all-features`. Default eyre features were added as default color-eyre features.

As it stands the resulting test suite is extremely long, 256 runs, too long for CI. The --chunks feature can be used to split up and parallelize this process, but it's still a too much for CI as it exists. Maybe some of the eyre features could be added manually to the CI, but I don't know what combinations we'd be interested in - @pksunkara had some ideas though. If we reduce the combinatorial complexity some with a more restrained cargo-all-features configuration maybe that'd be something we'd like to pursue!